### PR TITLE
:memo: Remove OAUTH_APP_EXTENSIONS

### DIFF
--- a/Sources/OAuthSwiftHTTPRequest.swift
+++ b/Sources/OAuthSwiftHTTPRequest.swift
@@ -8,9 +8,7 @@
 
 import Foundation
 #if os(iOS)
-#if !OAUTH_APP_EXTENSIONS
 import UIKit
-#endif
 #endif
 
 let kHTTPHeaderContentType = "Content-Type"
@@ -103,9 +101,7 @@ open class OAuthSwiftHTTPRequest: NSObject, OAuthSwiftRequestHandle {
             self.session.finishTasksAndInvalidate()
 
             #if os(iOS)
-                #if !OAUTH_APP_EXTENSIONS
-                    UIApplication.shared.isNetworkActivityIndicatorVisible = self.config.sessionFactory.isNetworkActivityIndicatorVisible
-                #endif
+            UIApplication.shared.isNetworkActivityIndicatorVisible = self.config.sessionFactory.isNetworkActivityIndicatorVisible
             #endif
         }
     }
@@ -113,9 +109,7 @@ open class OAuthSwiftHTTPRequest: NSObject, OAuthSwiftRequestHandle {
     /// Function called when receiving data from server.
     public static func completionHandler(completionHandler completion: CompletionHandler?, request: URLRequest, data: Data?, resp: URLResponse?, error: Error?) {
         #if os(iOS)
-        #if !OAUTH_APP_EXTENSIONS
         UIApplication.shared.isNetworkActivityIndicatorVisible = false
-        #endif
         #endif
 
         // MARK: failure error returned by server

--- a/Sources/OAuthSwiftURLHandlerType.swift
+++ b/Sources/OAuthSwiftURLHandlerType.swift
@@ -27,9 +27,7 @@ open class OAuthSwiftOpenURLExternally: OAuthSwiftURLHandlerType {
 
     @objc open func handle(_ url: URL) {
         #if os(iOS) || os(tvOS)
-            #if !OAUTH_APP_EXTENSIONS
-                UIApplication.shared.openURL(url)
-            #endif
+        UIApplication.shared.openURL(url)
         #elseif os(watchOS)
         // WATCHOS: not implemented
         #elseif os(OSX)
@@ -62,14 +60,10 @@ import AuthenticationServices
                                                                 let msg = error?.localizedDescription.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
                                                                 let urlString = "\(self.callbackUrlScheme)?error=\(msg ?? "UNKNOWN")"
                                                                 let url = URL(string: urlString)!
-                                                                #if !OAUTH_APP_EXTENSIONS
-                                                                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                                                                #endif
+                                                                UIApplication.shared.open(url, options: [:], completionHandler: nil)
                                                                 return
                                                             }
-                                                            #if !OAUTH_APP_EXTENSIONS
-                                                                UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
-                                                            #endif
+                                                            UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
             })
 
             _ = webAuthSession.start()
@@ -93,14 +87,10 @@ import AuthenticationServices
                                                             let msg = error?.localizedDescription.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
                                                             let urlString = "\(self.callbackUrlScheme)?error=\(msg ?? "UNKNOWN")"
                                                             let url = URL(string: urlString)!
-                                                            #if !OAUTH_APP_EXTENSIONS
-                                                                UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                                                            #endif
+                                                            UIApplication.shared.open(url, options: [:], completionHandler: nil)
                                                             return
                                                         }
-                                                        #if !OAUTH_APP_EXTENSIONS
-                                                            UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
-                                                        #endif
+                                                        UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
             })
 
             _ = webAuthSession.start()

--- a/Sources/OAuthWebViewController.swift
+++ b/Sources/OAuthWebViewController.swift
@@ -53,11 +53,7 @@ open class OAuthWebViewController: OAuthViewController, OAuthSwiftURLHandlerType
     public var dismissViewControllerAnimated = true
 
     public var topViewController: UIViewController? {
-        #if !OAUTH_APP_EXTENSIONS
-            return UIApplication.topViewController
-        #else
-            return nil
-        #endif
+        return UIApplication.topViewController
     }
     #elseif os(OSX)
     /// How to present this view controller if parent view controller set

--- a/Sources/UIApplication+OAuthSwift.swift
+++ b/Sources/UIApplication+OAuthSwift.swift
@@ -11,11 +11,7 @@
 
     extension UIApplication {
         @nonobjc static var topViewController: UIViewController? {
-            #if !OAUTH_APP_EXTENSIONS
-                return UIApplication.shared.topViewController
-            #else
-                return nil
-            #endif
+            return UIApplication.shared.topViewController
         }
 
         var topViewController: UIViewController? {


### PR DESCRIPTION
## What
Remove !OAUTH_APP_EXTENSIONS condition.

## Why
I got compile error [this statement](https://github.com/OAuthSwift/OAuthSwift/blob/master/Sources/OAuthSwiftHTTPRequest.swift#L107) when installed and build it.
UIKit does not import when it is not !OAUTH_APP_EXTENSIONS.
And it is not possible set `OAUTH_APP_EXTENSIONS` to `OTHER_SWIFT_FLAG` for Swift Package Manager on Xcode.



